### PR TITLE
Add support for Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+ARG INSTALL_PYTHON_VERSION=3.6
+FROM python:${INSTALL_PYTHON_VERSION}-slim-buster AS base
+
+RUN apt-get update
+RUN apt-get install -y g++ libxml2-dev libxslt-dev python3-dev lib32z1-dev
+
+WORKDIR /app
+COPY . .
+
+RUN useradd -m sid
+RUN chown -R sid:sid /app
+USER sid
+ENV PATH="/home/sid/.local/bin:${PATH}"
+
+RUN pip install --user -r requirements.txt
+
+EXPOSE 5000
+CMD ["python", "wsgi.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.6'
+
+services:
+    web:
+        build: .
+        ports:
+            - "5003:5000"


### PR DESCRIPTION
This will allow developers to use `docker-compose up web` to spin up the service inside a Docker. No need to install Python packages locally any more.