### PR TITLE
Add fake UA and update MarkupSafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ colorama==0.3.9
 cssselect==1.0.1
 docopt==0.6.2
 et-xmlfile==1.0.1
+fake_useragent==0.1.11
 Flask==0.12.2
 gevent==1.2.2
 greenlet==0.4.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ itsdangerous==0.24
 jdcal==1.3
 Jinja2==2.10
 lxml==4.1.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 odfpy==1.3.6
 openpyxl==2.4.9
 pycrypto==2.6.1

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,6 @@
 import os
 
+from fake_useragent import UserAgent
 from toapi.cache import MemoryCache, RedisCache, JsonSerializer
 from toapi.settings import Settings
 
@@ -18,7 +19,7 @@ class MemCacheSettings(Settings):
     }
     web = {
         "with_ajax": False,
-        "request_config": {},
+        "request_config": {"headers": {'User-Agent': UserAgent().random}},
         "headers": None
     }
 
@@ -41,6 +42,6 @@ class RedisCacheSettings(Settings):
     }
     web = {
         "with_ajax": False,
-        "request_config": {},
+        "request_config": {"headers": {'User-Agent': UserAgent().random}},
         "headers": None
     }


### PR DESCRIPTION
1. Update Markupsafe due to https://github.com/pallets/markupsafe/issues/116
2. Add fake user agent to the default setting: the website is rejecting requests with 404 if the user agent is not set